### PR TITLE
security(rng): use SecureRandom for every RandomStringGenerator (VB-29)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.takamaka.wallet</groupId>
     <artifactId>takamaka-core-wallet</artifactId>
-    <version>0.10.0-SNAPSHOT</version>
+    <version>0.10.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <!--
         0.10.0 — minor bump signaling:

--- a/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCCurve25519.java
+++ b/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCCurve25519.java
@@ -59,6 +59,11 @@ import org.bouncycastle.util.encoders.UrlBase64;
  */
 @Slf4j
 public class InstanceWalletKeyStoreBCCurve25519 implements InstanceWalletKeystoreInterface {
+    /** VB-29: CSPRNG for every RandomStringGenerator in this class. commons-text falls back to
+     *  ThreadLocalRandom when no provider is supplied — a 64-bit clock-seeded root shared by the whole
+     *  JVM. See rschat-docs/security/PRNG_ENTROPY_AUDIT.md. */
+    private static final java.security.SecureRandom TKM_CSPRNG = new java.security.SecureRandom();
+
 
     private Map<Integer, AsymmetricCipherKeyPair> signKeys;
     private Map<Integer, String> hexPublicKeys;
@@ -306,6 +311,7 @@ public class InstanceWalletKeyStoreBCCurve25519 implements InstanceWalletKeystor
             RandomStringGenerator generator = new RandomStringGenerator.Builder()
                     .withinRange('0', 'z')
                     .filteredBy(Character::isLetterOrDigit)
+                    .usingRandom(TKM_CSPRNG::nextInt)
                     .get();
             seed = generator.generate(seedLength);
             FileHelper.writeStringToFile(ephDir, currentWalletName, seed, false);

--- a/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCED25519.java
+++ b/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCED25519.java
@@ -55,6 +55,11 @@ import org.bouncycastle.util.encoders.UrlBase64;
  */
 @Slf4j
 public class InstanceWalletKeyStoreBCED25519 implements InstanceWalletKeystoreInterface {
+    /** VB-29: CSPRNG for every RandomStringGenerator in this class. commons-text falls back to
+     *  ThreadLocalRandom when no provider is supplied — a 64-bit clock-seeded root shared by the whole
+     *  JVM. See rschat-docs/security/PRNG_ENTROPY_AUDIT.md. */
+    private static final java.security.SecureRandom TKM_CSPRNG = new java.security.SecureRandom();
+
 
     private Map<Integer, AsymmetricCipherKeyPair> signKeys;
     private Map<Integer, String> hexPublicKeys;
@@ -388,6 +393,7 @@ public class InstanceWalletKeyStoreBCED25519 implements InstanceWalletKeystoreIn
             RandomStringGenerator generator = new RandomStringGenerator.Builder()
                     .withinRange('0', 'z')
                     .filteredBy(Character::isLetterOrDigit)
+                    .usingRandom(TKM_CSPRNG::nextInt)
                     .get();
             seed = generator.generate(seedLength);
             FileHelper.writeStringToFile(ephDir, currentWalletName, seed, false);

--- a/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCQTESLAPSSC1Round1.java
+++ b/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCQTESLAPSSC1Round1.java
@@ -53,6 +53,11 @@ import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
  */
 @Slf4j
 public class InstanceWalletKeyStoreBCQTESLAPSSC1Round1 implements InstanceWalletKeystoreInterface {
+    /** VB-29: CSPRNG for every RandomStringGenerator in this class. commons-text falls back to
+     *  ThreadLocalRandom when no provider is supplied — a 64-bit clock-seeded root shared by the whole
+     *  JVM. See rschat-docs/security/PRNG_ENTROPY_AUDIT.md. */
+    private static final java.security.SecureRandom TKM_CSPRNG = new java.security.SecureRandom();
+
 
     private Map<Integer, AsymmetricCipherKeyPair> signKeys;
     private Map<Integer, String> hexPublicKeys;
@@ -234,6 +239,7 @@ public class InstanceWalletKeyStoreBCQTESLAPSSC1Round1 implements InstanceWallet
             RandomStringGenerator generator = new RandomStringGenerator.Builder()
                     .withinRange('0', 'z')
                     .filteredBy(Character::isLetterOrDigit)
+                    .usingRandom(TKM_CSPRNG::nextInt)
                     .get();
             seed = generator.generate(seedLength);
             FileHelper.writeStringToFile(ephDir, currentWalletName, seed, false);

--- a/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCQTESLAPSSC1Round2.java
+++ b/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCQTESLAPSSC1Round2.java
@@ -53,6 +53,11 @@ import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
  */
 @Slf4j
 public class InstanceWalletKeyStoreBCQTESLAPSSC1Round2 implements InstanceWalletKeystoreInterface {
+    /** VB-29: CSPRNG for every RandomStringGenerator in this class. commons-text falls back to
+     *  ThreadLocalRandom when no provider is supplied — a 64-bit clock-seeded root shared by the whole
+     *  JVM. See rschat-docs/security/PRNG_ENTROPY_AUDIT.md. */
+    private static final java.security.SecureRandom TKM_CSPRNG = new java.security.SecureRandom();
+
 
     private Map<Integer, AsymmetricCipherKeyPair> signKeys;
     private Map<Integer, String> hexPublicKeys;
@@ -233,6 +238,7 @@ public class InstanceWalletKeyStoreBCQTESLAPSSC1Round2 implements InstanceWallet
             RandomStringGenerator generator = new RandomStringGenerator.Builder()
                     .withinRange('0', 'z')
                     .filteredBy(Character::isLetterOrDigit)
+                    .usingRandom(TKM_CSPRNG::nextInt)
                     .get();
             seed = generator.generate(seedLength);
             FileHelper.writeStringToFile(ephDir, currentWalletName, seed, false);

--- a/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCRSA4096ENC.java
+++ b/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCRSA4096ENC.java
@@ -64,6 +64,11 @@ import org.bouncycastle.util.encoders.UrlBase64;
  */
 @Slf4j
 public class InstanceWalletKeyStoreBCRSA4096ENC implements InstanceWalletKeystoreInterface {
+    /** VB-29: CSPRNG for every RandomStringGenerator in this class. commons-text falls back to
+     *  ThreadLocalRandom when no provider is supplied — a 64-bit clock-seeded root shared by the whole
+     *  JVM. See rschat-docs/security/PRNG_ENTROPY_AUDIT.md. */
+    private static final java.security.SecureRandom TKM_CSPRNG = new java.security.SecureRandom();
+
 
     private Map<Integer, AsymmetricCipherKeyPair> signKeys;
     private Map<Integer, String> hexPublicKeys;
@@ -312,6 +317,7 @@ public class InstanceWalletKeyStoreBCRSA4096ENC implements InstanceWalletKeystor
             RandomStringGenerator generator = new RandomStringGenerator.Builder()
                     .withinRange('0', 'z')
                     .filteredBy(Character::isLetterOrDigit)
+                    .usingRandom(TKM_CSPRNG::nextInt)
                     .get();
             seed = generator.generate(seedLength);
             FileHelper.writeStringToFile(ephDir, currentWalletName, seed, false);

--- a/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCRSA4096ENC256.java
+++ b/src/main/java/io/takamaka/wallet/InstanceWalletKeyStoreBCRSA4096ENC256.java
@@ -72,6 +72,11 @@ import org.bouncycastle.util.encoders.UrlBase64;
  */
 @Slf4j
 public class InstanceWalletKeyStoreBCRSA4096ENC256 implements InstanceWalletKeystoreInterface {
+    /** VB-29: CSPRNG for every RandomStringGenerator in this class. commons-text falls back to
+     *  ThreadLocalRandom when no provider is supplied — a 64-bit clock-seeded root shared by the whole
+     *  JVM. See rschat-docs/security/PRNG_ENTROPY_AUDIT.md. */
+    private static final java.security.SecureRandom TKM_CSPRNG = new java.security.SecureRandom();
+
 
     private Map<Integer, AsymmetricCipherKeyPair> signKeys;
     private Map<Integer, String> hexPublicKeys;
@@ -319,6 +324,7 @@ public class InstanceWalletKeyStoreBCRSA4096ENC256 implements InstanceWalletKeys
             RandomStringGenerator generator = new RandomStringGenerator.Builder()
                     .withinRange('0', 'z')
                     .filteredBy(Character::isLetterOrDigit)
+                    .usingRandom(TKM_CSPRNG::nextInt)
                     .get();
             seed = generator.generate(seedLength);
             FileHelper.writeStringToFile(ephDir, currentWalletName, seed, false);


### PR DESCRIPTION
commons-text RandomStringGenerator falls back to ThreadLocalRandom when no provider is supplied, and JDK ThreadLocalRandom seeds one process-wide AtomicLong from mixMurmur64(currentTimeMillis()) ^ mixMurmur64(nanoTime()). Every thread derives from it by adding public constants, so thread separation adds no entropy: every random string the JVM produced was a deterministic function of one 64-bit number. Demonstrated -- two separate JVMs with the same forced seeder produced byte-identical output on different threads.

Each affected class gains a shared static SecureRandom and passes it via .usingRandom(TKM_CSPRNG::nextInt). Alphabet, length and distribution are unchanged -- commons-text rejection sampling keeps the output uniform over 62 symbols and SecureRandom.nextInt is unbiased -- so this is wire-neutral and no cross-platform vector moves. new SecureRandom() (NativePRNG, non-blocking) is used deliberately rather than getInstanceStrong(), which can block.

Full analysis, entropy arithmetic, the wire-side verification oracle and the threat models: rschat-docs/security/PRNG_ENTROPY_AUDIT.md